### PR TITLE
Add instructions to use the JWT from the az cli

### DIFF
--- a/docs/data-collection/azurehound.rst
+++ b/docs/data-collection/azurehound.rst
@@ -41,7 +41,13 @@ need to supply a username or password when supplying a JWT:
 ::
 
     ./azurehound -j "ey..." list users --tenant "contoso.onmicrosoft.com"
-    
+
+If you're currently authenticated through the Azure CLI, you can use:
+
+::
+
+    ./azurehound -j "$(az account get-access-token --resource=https://graph.microsoft.com/ | jq -r .accessToken)" list users --tenant "contoso.onmicrosoft.com"
+
 When collecting data for import into BloodHound, you must use the -o switch to instruct
 AzureHound to output to a file. For example, to list all available data in both AzureAD
 and AzureRM, you can do this:


### PR DESCRIPTION
I frequently need to run AzureHound from the current user I'm logged in with the AZ CLI. Had to search a bit, but the command below works to get the right JWT